### PR TITLE
corrige nome da branch principal do workflow ci

### DIFF
--- a/.github/workflows/Python_CI.yml
+++ b/.github/workflows/Python_CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   
   workflow_dispatch:
 

--- a/config.json
+++ b/config.json
@@ -1,3 +1,3 @@
 {
-  "mergeVersion": "8"
+  "mergeVersion": "9"
 }


### PR DESCRIPTION
"main" → master

Isso estava fazendo com que o CI nao rodasse em PR